### PR TITLE
Getting Started typo fix

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -22,7 +22,7 @@ Clone the Acetate sample project and `cd` into it:
 $ git clone https://github.com/patrickarlt/acetate-sample.git && cd ./acetate-sample
 ```
 
-Intall the dependencies with NPM:
+Install the dependencies with NPM:
 
 ```bash
 $ npm install


### PR DESCRIPTION
Found a typo when running through the Getting Started page.
